### PR TITLE
docs: update all documentation to reflect Connect-RPC migration and a…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ health: ## Check health of all services
 	@echo "Redis:"
 	@docker-compose exec redis redis-cli ping || echo "Redis not ready"
 	@echo "User Service:"
-	@curl -sf http://localhost:8080/health >/dev/null && echo "User service healthy" || echo "User service not ready"
+	@curl -sf http://localhost:8100/health >/dev/null && echo "User service healthy" || echo "User service not ready"
 
 # Database utilities
 db-reset: ## Reset database (drop and recreate)

--- a/README.md
+++ b/README.md
@@ -4,17 +4,93 @@ A **Clean Architecture** microservices application for collaborative travel plan
 
 ## Quick Start with Docker
 
+### Prerequisites
+- Docker Desktop installed and running
+- Git
+- Make (optional, for shortcuts)
+
+### Getting Started
+
+1. **Clone the repository**
+   ```bash
+   git clone <repository-url>
+   cd go-shop
+   ```
+
+2. **Start all services**
+   ```bash
+   make dev
+   ```
+   This will start PostgreSQL, Redis, NATS, and the user service with hot reload.
+
+3. **Verify services are running**
+   ```bash
+   make health
+   ```
+
+4. **Access services**
+   - User Service: http://localhost:8100
+   - Database: localhost:5432 (postgres/password)
+   - Redis: localhost:6379
+   - NATS: localhost:4222
+
+### First Time Setup
+
 ```bash
-# Start all services
-make dev
+# Apply database migrations
+make migrate-up
 
-# View logs
+# Generate protobuf and SQLC code
+make gen
+
+# View logs to ensure everything is working
 make logs
+```
 
-# Access services
-# User Service: http://localhost:8080
-# Database: localhost:5432
-# Redis: localhost:6379
+### Development Workflow
+
+```bash
+# View real-time logs
+make logs-user
+
+# Access service container for debugging
+make shell
+
+# Reset database if needed
+make db-reset
+
+# Stop all services
+make stop
+```
+
+### Troubleshooting
+
+**Services won't start:**
+```bash
+# Check if Docker is running
+docker --version
+
+# Clean up and restart
+make clean
+make dev
+```
+
+**Database connection issues:**
+```bash
+# Check database status
+make shell-db
+
+# Reset database if corrupted
+make db-reset
+```
+
+**Port conflicts:**
+```bash
+# Check what's using port 8100
+lsof -i :8100
+
+# Kill processes using the port
+sudo lsof -ti:8100 | xargs sudo kill -9
 ```
 
 ## Table of Contents
@@ -55,7 +131,7 @@ make migrate-up   # Run database migrations
 
 **Services**
 
-- **user-service** (Port 8080): User management, authentication, profiles
+- **user-service** (Port 8100): User management, authentication, profiles
 - **product-service** (Port 8081): Coming soon
 
 ## Services
@@ -63,7 +139,7 @@ make migrate-up   # Run database migrations
 ### User Service
 
 - **Status**: ✅ Active Development
-- **Port**: 8080
+- **Port**: 8100
 - **Database**: user_db
 - **Features**: User registration, authentication, profile management
 - **Documentation**: [User Service Docs](services/user-service/docs/README.md)
@@ -88,7 +164,7 @@ This project follows **Clean Architecture** principles with strict dependency ru
 - **Language**: Go 1.24.2
 - **Database**: PostgreSQL with pgx/v5
 - **Cache**: Redis
-- **API**: Echo framework + Connect-Go (planned)
+- **API**: Connect-RPC for type-safe HTTP/gRPC
 - **Code Generation**: SQLC for type-safe SQL, Buf for protobuf
 - **Migration**: golang-migrate
 - **Messaging**: NATS (planned)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       timeout: 5s
       retries: 5
 
-  # User Service (Development mode with hot reload)
+  # User Service (Connect-RPC API with hot reload)
   user-service:
     build:
       context: ./services/user-service
@@ -88,7 +88,7 @@ services:
           "--no-verbose",
           "--tries=1",
           "--spider",
-          "http://localhost:8080/health",
+          "http://localhost:8100/health",
         ]
       interval: 30s
       timeout: 10s

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ Go Shop is a microservices-based travel planning application built with Clean Ar
 
 ### Service Map
 
-- **user-service** (Port 8080): User management, authentication, profile handling
+- **user-service** (Port 8100): User management, authentication, profile handling
 - **product-service** (Port 8081): Planned - Product and service catalog management
 - **order-service** (Planned): Order processing and booking management
 
@@ -52,7 +52,7 @@ Go Shop is a microservices-based travel planning application built with Clean Ar
    ```
 
 3. **Access Services**
-   - User Service: http://localhost:8080
+   - User Service: http://localhost:8100
    - Database: localhost:5432
    - Redis: localhost:6379
 
@@ -74,7 +74,7 @@ Go Shop is a microservices-based travel planning application built with Clean Ar
 - **Language**: Go 1.24.2
 - **Database**: PostgreSQL 16 with pgx/v5 driver
 - **Cache**: Redis 7
-- **API Framework**: Echo v4 + Connect-Go (planned)
+- **API Framework**: Connect-RPC for type-safe HTTP/gRPC
 - **Message Broker**: NATS JetStream
 
 ### Development Tools

--- a/docs/services-overview.md
+++ b/docs/services-overview.md
@@ -8,7 +8,7 @@ Go Shop follows a microservices architecture where each service is responsible f
 
 ### User Service
 - **Status**: ✅ Active Development
-- **Port**: 8080
+- **Port**: 8100
 - **Database**: user_db
 - **Redis DB**: 0
 - **Repository**: `services/user-service/`
@@ -83,7 +83,7 @@ make migrate-up
 ## Service Communication
 
 ### Synchronous Communication
-- **Protocol**: HTTP/HTTPS with Connect-Go (planned)
+- **Protocol**: HTTP/HTTPS with Connect-RPC
 - **Format**: Protocol Buffers
 - **Authentication**: JWT tokens
 - **Load Balancing**: Via container orchestration
@@ -201,7 +201,7 @@ REDIS_DB=2
 make health
 
 # Individual service health endpoints
-curl http://localhost:8080/health  # User Service
+curl http://localhost:8100/health  # User Service
 curl http://localhost:8081/health  # Product Service (planned)
 ```
 

--- a/docs/setup/docker-development.md
+++ b/docs/setup/docker-development.md
@@ -17,7 +17,7 @@ This guide covers the complete Docker-based development environment for Go Shop.
 ```
 ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
 │   user-service  │    │ product-service │    │  order-service  │
-│     :8080       │    │     :8081       │    │     :8082       │
+│     :8100       │    │     :8081       │    │     :8082       │
 └─────────────────┘    └─────────────────┘    └─────────────────┘
          │                       │                       │
          └───────────────────────┼───────────────────────┘
@@ -51,7 +51,7 @@ make health
 ```
 
 ### 2. Service Access
-- **User Service**: http://localhost:8080
+- **User Service**: http://localhost:8100
 - **PostgreSQL**: localhost:5432 (postgres/password)
 - **Redis**: localhost:6379
 - **NATS**: localhost:4222, Management: localhost:8222
@@ -236,11 +236,11 @@ go mod tidy
 #### Port Conflicts
 ```bash
 # Check what's using ports
-lsof -i :8080
+lsof -i :8100
 lsof -i :5432
 
 # Stop conflicting services
-sudo lsof -ti:8080 | xargs sudo kill -9
+sudo lsof -ti:8100 | xargs sudo kill -9
 ```
 
 ### Performance Optimization

--- a/services/user-service/docs/README.md
+++ b/services/user-service/docs/README.md
@@ -25,7 +25,7 @@ The User Service implements Clean Architecture with four distinct layers:
 
 - **[Domain Layer](architecture/domain-layer.md)**: Business entities, value objects, and domain logic
 - **[Application Layer](architecture/application-layer.md)**: Use cases and business orchestration
-- **[Adapter Layer](architecture/adapter-layer.md)**: HTTP/gRPC handlers and external interfaces
+- **[Adapter Layer](architecture/adapter-layer.md)**: Connect-RPC handlers and external interfaces
 - **[Infrastructure Layer](architecture/infrastructure-layer.md)**: Database, cache, and external service implementations
 
 ## APIs


### PR DESCRIPTION
…dd comprehensive project setup guide #4

- Update port references from 8080 to 8100 across all documentation
- Update API framework references from Echo to Connect-RPC
- Add detailed getting started guide with prerequisites and step-by-step instructions
- Add troubleshooting section for common development issues
- Update service architecture descriptions to reflect Connect-RPC implementation
- Update health check URLs and development commands
- Ensure consistency across README, docs/, and service-specific documentation